### PR TITLE
Fix libappimage not being able to find .desktop file

### DIFF
--- a/gcc/deploy-linux.sh
+++ b/gcc/deploy-linux.sh
@@ -151,8 +151,8 @@ patchelf --set-rpath '$ORIGIN/../lib' $_EXECUTABLE
 _APPDIR=$2
 cd ${_APPDIR}
 
-cp -nvs $(find -type f -regex '.*/icons/.*\.svg' || head -n 1) ./
-cp -nvs $(find -type f -regex '.*/applications/.*\.desktop' || head -n 1) ./
+cp -nvs $(find -type f -regex '.*/icons/.*\.svg' -printf '%P\n' || head -n 1) ./
+cp -nvs $(find -type f -regex '.*/applications/.*\.desktop' -printf '%P\n' || head -n 1) ./
 
 if [ "${_NOT_FOUND}" != "" ]; then
   >&2 echo "WARNING: failed to find the following libraries:"


### PR DESCRIPTION
When trying to integrate yuzu via appimaged you currently receive the error message `Failed to register AppImage in system via libappimage`.

This is caused by the symlinks for the .desktop file and the icon starting with a `./`.

This PR omits the prefixed `./` with `find`s printf argument, not changing the meaning of the link but allowing libappimage to find the .desktop file.

Fixes https://github.com/yuzu-emu/yuzu/issues/9268